### PR TITLE
make  a singleton and use FFI::scope or FFI::load when possible

### DIFF
--- a/src/PcapFFI.php
+++ b/src/PcapFFI.php
@@ -15,26 +15,42 @@ class PcapFFI
 {
     public const LIBPCAP_NAME = 'libpcap.so.1';
 
-    private FFI $ffi;
+    static private $ffi = NULL;
 
     private ?string $error = null;
 
     public function __construct()
     {
-        $env = getenv('LIBPCAP_NAME');
-        $lib = ($env !== false) ? $env : self::LIBPCAP_NAME;
-        $code = file_get_contents(__DIR__ . '/pcap.h');
-
-        if ($code === false) {
-            throw new Exception('Cannot load pcap C definitions');
+        if (self::$ffi) {
+            return;
         }
 
-        $this->ffi = FFI::cdef($code, $lib);
+        $lib = getenv('LIBPCAP_NAME');
+        if ($lib) {
+            // old way
+            $code = file_get_contents(__DIR__ . '/pcap.h');
+
+            if ($code === false) {
+                throw new Exception('Cannot load pcap C definitions');
+            }
+            self::$ffi = FFI::cdef($code, $lib);
+        } else {
+            try {
+                // Try preload
+                self::$ffi = \FFI::scope("_RTCKIT_PCAP_FFI_");
+            } catch (\FFI\Exception $e) {
+                // Try direct load
+                self::$ffi = \FFI::load(__DIR__ . '/pcap.h');
+            }
+        }
+        if (!self::$ffi) {
+            throw new \RuntimeException("FFI parse fails");
+        }
     }
 
     public function lib_version(): string
     {
-        return $this->ffi->pcap_lib_version();
+        return self::$ffi->pcap_lib_version();
     }
 
     /**
@@ -47,11 +63,11 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $devs = $this->ffi->new('pcap_if_t *');
-        $dev = $this->ffi->new('pcap_if_t *');
-        $err = $this->ffi->new('char[257]');
+        $devs = self::$ffi->new('pcap_if_t *');
+        $dev = self::$ffi->new('pcap_if_t *');
+        $err = self::$ffi->new('char[257]');
 
-        if ($this->ffi->pcap_findalldevs(FFI::addr($devs), $err) < 0) {
+        if (self::$ffi->pcap_findalldevs(FFI::addr($devs), $err) < 0) {
             $this->setLastError(FFI::string($err));
 
             return null;
@@ -68,7 +84,7 @@ class PcapFFI
             $dev = $dev->next;
         }
 
-        $this->ffi->pcap_freealldevs($devs);
+        self::$ffi->pcap_freealldevs($devs);
 
         return $ret;
     }
@@ -77,8 +93,8 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $err = $this->ffi->new('char[257]');
-        $ret = $this->ffi->pcap_create($dev, $err);
+        $err = self::$ffi->new('char[257]');
+        $ret = self::$ffi->pcap_create($dev, $err);
 
         if (is_null($ret)) {
             $this->setLastError(FFI::string($err));
@@ -93,7 +109,7 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $ret = $this->ffi->pcap_set_snaplen($pcap, $snaplen);
+        $ret = self::$ffi->pcap_set_snaplen($pcap, $snaplen);
 
         if ($ret < 0) {
             $this->setLastPcapError($pcap);
@@ -106,7 +122,7 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $ret = $this->ffi->pcap_set_promisc($pcap, $promisc);
+        $ret = self::$ffi->pcap_set_promisc($pcap, $promisc);
 
         if ($ret < 0) {
             $this->setLastPcapError($pcap);
@@ -119,7 +135,7 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $ret = $this->ffi->pcap_set_immediate_mode($pcap, $immediate_mode);
+        $ret = self::$ffi->pcap_set_immediate_mode($pcap, $immediate_mode);
 
         if ($ret < 0) {
             $this->setLastPcapError($pcap);
@@ -132,7 +148,7 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $ret = $this->ffi->pcap_set_timeout($pcap, $to_ms);
+        $ret = self::$ffi->pcap_set_timeout($pcap, $to_ms);
 
         if ($ret < 0) {
             $this->setLastPcapError($pcap);
@@ -145,8 +161,8 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $err = $this->ffi->new('char[257]');
-        $ret = $this->ffi->pcap_setnonblock($pcap, $nonblock, $err);
+        $err = self::$ffi->new('char[257]');
+        $ret = self::$ffi->pcap_setnonblock($pcap, $nonblock, $err);
 
         if ($ret < 0) {
             $this->setLastError(FFI::string($err));
@@ -159,7 +175,7 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $ret = $this->ffi->pcap_activate($pcap);
+        $ret = self::$ffi->pcap_activate($pcap);
 
         if ($ret < 0) {
             $this->setLastPcapError($pcap);
@@ -170,21 +186,21 @@ class PcapFFI
 
     public function get_selectable_fd(CData $pcap): int
     {
-        return $this->ffi->pcap_get_selectable_fd($pcap);
+        return self::$ffi->pcap_get_selectable_fd($pcap);
     }
 
     public function inject(CData $pcap, string $data): int
     {
-        return $this->ffi->pcap_inject($pcap, $data, strlen($data));
+        return self::$ffi->pcap_inject($pcap, $data, strlen($data));
     }
 
     public function next_ex(CData $pcap): string
     {
         $this->resetLastError();
 
-        $header = $this->ffi->new('struct pcap_pkthdr *');
-        $data = $this->ffi->new('const u_char *');
-        $next = $this->ffi->pcap_next_ex($pcap, FFI::addr($header), FFI::addr($data));
+        $header = self::$ffi->new('struct pcap_pkthdr *');
+        $data = self::$ffi->new('const u_char *');
+        $next = self::$ffi->pcap_next_ex($pcap, FFI::addr($header), FFI::addr($data));
 
         if ($next < 0) {
             $this->setLastPcapError($pcap);
@@ -203,13 +219,13 @@ class PcapFFI
     {
         $this->resetLastError();
 
-        $fp = $this->ffi->new('struct bpf_program');
-        $ret = $this->ffi->pcap_compile($pcap, FFI::addr($fp), $filter, 0, 0);
+        $fp = self::$ffi->new('struct bpf_program');
+        $ret = self::$ffi->pcap_compile($pcap, FFI::addr($fp), $filter, 0, 0);
 
         if ($ret < 0) {
             $this->setLastPcapError($pcap);
         } else {
-            $ret = $this->ffi->pcap_setfilter($pcap, FFI::addr($fp));
+            $ret = self::$ffi->pcap_setfilter($pcap, FFI::addr($fp));
 
             if ($ret < 0) {
                 $this->setLastPcapError($pcap);
@@ -221,7 +237,7 @@ class PcapFFI
 
     public function close(CData $pcap): void
     {
-        $this->ffi->pcap_close($pcap);
+        self::$ffi->pcap_close($pcap);
     }
 
     public function getLastError(): string
@@ -236,7 +252,7 @@ class PcapFFI
 
     private function setLastPcapError(CData $pcap): void
     {
-        $err = $this->ffi->pcap_geterr($pcap);
+        $err = self::$ffi->pcap_geterr($pcap);
 
         if (!is_null($err)) {
             $this->setLastError(FFI::string($err));

--- a/src/pcap.h
+++ b/src/pcap.h
@@ -1,3 +1,6 @@
+#define FFI_SCOPE "_RTCKIT_PCAP_FFI_"
+#define FFI_LIB   "libpcap.so.1"
+
 typedef unsigned long int time_t;
 typedef unsigned long int suseconds_t;
 


### PR DESCRIPTION
`FFI:scope` should be the preferred way, as if can be used everywhere (all users, all SAPI)

`FFI::load` is a fallback, CLI only

`FFI::cdef `is kept for BC, and to allow LIBPCAP_NAME from env, despite I think this is a bad idea.
libpcap.so.1 is a link to current version, and a ABI warranty.

If someday, you have a libpcap.so.2, this will imply a new API/ABI, so a new pcap.h


Using this changes, you can run

* `php vendor/bin/phpunit` => **FFI:load** usage
* `php -d ffi.preload=$PWD/src/pcap.h vendor/bin/phpunit` => **FFI::scope** usage
* `LIBPCAP_NAME=libpcap.so.1 php vendor/bin/phpunit` =>  **FFI::cdef** usage

With 3 runs (test skipped from PR #2  )
```
OK, but incomplete, skipped, or risky tests!
Tests: 11, Assertions: 56, Skipped: 1.
```